### PR TITLE
Fix password property not being of type password

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ Remember:
 - DO file issues here on GitHub, so that the community can pitch in
 - Phew, that was easier than I thought. Last but not least of all:
 
-Have fun creating and using this utility to quikcly get hands-on with Nexus Repository and Nexus Lifecycle. We are glad to have you here!
+Have fun creating and using this utility to quickly get hands-on with Nexus Repository and Nexus Lifecycle. We are glad to have you here!

--- a/teamcity-iq-plugin-server/src/main/resources/buildServerResources/editIQRunnerParameters.jsp
+++ b/teamcity-iq-plugin-server/src/main/resources/buildServerResources/editIQRunnerParameters.jsp
@@ -55,7 +55,7 @@
 		</th>
 		<td>
 			<div class="posRel">
-				<props:textProperty name="${password}" size="56" maxlength="100"/>
+				<props:passwordProperty name="${password}" size="56" maxlength="100"/>
 				<span class="error" id="error_${password}"/>
 			</div>
 		</td>

--- a/teamcity-iq-plugin-server/src/main/resources/buildServerResources/viewIQRunnerParameters.jsp
+++ b/teamcity-iq-plugin-server/src/main/resources/buildServerResources/viewIQRunnerParameters.jsp
@@ -2,7 +2,6 @@
 <%@ taglib prefix="props" tagdir="/WEB-INF/tags/props" %>
 <c:set var="iqserver" value="<%=IQRunnerConstants.IQ_SERVER_KEY%>"/>
 <c:set var="username" value="<%=IQRunnerConstants.IQ_USERNAME_KEY%>"/>
-<c:set var="password" value="<%=IQRunnerConstants.IQ_PASSWORD_KEY%>"/>
 <c:set var="applicationid" value="<%=IQRunnerConstants.IQ_APPLICATIONID_KEY%>"/>
 <c:set var="stage" value="<%=IQRunnerConstants.IQ_STAGE_KEY%>"/>
 <c:set var="scantarget" value="<%=IQRunnerConstants.IQ_SCANTARGET_KEY%>"/>
@@ -11,7 +10,6 @@
 <div class="parameter">
     iqserver: <props:displayValue name="${iqserver}" emptyValue=""/>
     username: <props:displayValue name="${username}" emptyValue=""/>
-    password: <props:displayValue name="${password}" emptyValue=""/>
     applicationid: <props:displayValue name="${applicationid}" emptyValue=""/>
     stage: <props:displayValue name="${stage}" emptyValue=""/>
     scantarget: <props:displayValue name="${scantarget}" emptyValue=""/>


### PR DESCRIPTION
This changes the password property to be passwordProperty instead of a textProperty.

This also means that Teamcity will try to mask it from the build log, though it's not perfect: https://www.jetbrains.com/help/teamcity/typed-parameters.html#Password+Type

I also removed it from the viewIQRunnerParameters.jsp file, you should never need to see the password again.
If you typed or copy-pasted the password incorrectly I'm sure you will get an authentication error, showing it like this I'm pretty sure everyone with read-only access to your Teamcity server would have access to this property.


**Not tested**